### PR TITLE
feat: configure DNS with PiHole and fallback servers

### DIFF
--- a/roles/dependencies/handlers/main.yml
+++ b/roles/dependencies/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart systemd-resolved
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    state: restarted

--- a/roles/dependencies/tasks/main.yml
+++ b/roles/dependencies/tasks/main.yml
@@ -8,3 +8,25 @@
     - python3
     - python3-pip
     - vim
+
+- name: Configure DNS with PiHole primary and Google fallback
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/resolved.conf
+    regexp: '^#?DNS='
+    line: 'DNS=192.168.87.101 8.8.8.8 8.8.4.4'
+    state: present
+  notify: Restart systemd-resolved
+
+- name: Configure DNS fallback servers
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/resolved.conf
+    regexp: '^#?FallbackDNS='
+    line: 'FallbackDNS=1.1.1.1 1.0.0.1'
+    state: present
+  notify: Restart systemd-resolved
+
+- name: Ensure systemd-resolved is enabled and running
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    enabled: true
+    state: started


### PR DESCRIPTION
## Summary

Configure systemd-resolved on all k3s nodes with PiHole as primary DNS and
Google/Cloudflare as fallback servers.

## Problem

Without fallback DNS, the cluster breaks when PiHole restarts:
- Nodes can't resolve DNS
- Can't pull container images
- Chicken-and-egg: PiHole can't start because it can't pull images

## Solution

Configure `/etc/systemd/resolved.conf` with:
- **Primary DNS:** 192.168.87.101 (PiHole)
- **Fallback DNS:** 8.8.8.8, 8.8.4.4 (Google)  
- **Secondary Fallback:** 1.1.1.1, 1.0.0.1 (Cloudflare)

## Changes

- Add DNS configuration to `dependencies` role
- Create handler to restart systemd-resolved on config changes
- Ensure systemd-resolved is enabled and running

## Test Plan

- [x] Pre-commit hooks passed
- [x] ansible-lint passed
- [ ] Run playbook against all nodes
- [ ] Verify `/etc/systemd/resolved.conf` updated
- [ ] Test DNS resolution: `resolvectl status`
- [ ] Test fallback: stop PiHole, verify cluster still resolves DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)