### PR TITLE
fix: add k3s system reserved resources to prevent OOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,12 @@ If you need to rebuild the cluster:
 
 ## Git Workflow
 
+> **CRITICAL:** Always use pull requests - no exceptions. NEVER commit or push
+> directly to `main`. ALL changes MUST go through a PR, even small fixes. This
+> applies to Claude Code sessions as well as manual changes.
+
+**Workflow Steps:**
+
 1. **Create feature branch:** `git checkout -b feature/description`
 1. **Make changes** to playbooks, roles, or documentation
 1. **ALWAYS run pre-commit BEFORE committing:** `pre-commit run --all-files`


### PR DESCRIPTION
## Summary
- Add `system-reserved=cpu=250m,memory=512Mi` kubelet arg to reserve resources for OS
- Add `kube-reserved=cpu=250m,memory=512Mi` kubelet arg to reserve resources for kubelet/containerd
- Add `eviction-hard=memory.available<500Mi,nodefs.available<10%` to evict pods before OOM
- Update CLAUDE.md to enforce PR workflow - no direct commits to main

## Problem
Both cluster nodes were showing OOM errors on their monitors. The k3s kubelet wasn't reserving any resources for the OS, allowing pods to consume all available memory.

## After merging
Run a rolling restart of k3s services:

```bash
# 1. Restart agent first
ssh -i ~/.ssh/ansible_key ansible@macmini-2010 "sudo systemctl restart k3s-agent"
# Wait for Ready: kubectl get nodes -w

# 2. Restart server last
ssh -i ~/.ssh/ansible_key ansible@hp-elitedesk "sudo systemctl restart k3s"
# Wait for Ready: kubectl get nodes -w

# 3. Verify
kubectl get nodes
kubectl describe nodes | grep -A 5 "Allocatable"
```

The Allocatable resources should now be ~1GB less than Capacity (system-reserved + kube-reserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)