### PR TITLE
fix: handle missing ufw and fix deprecation warnings

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -6,7 +6,7 @@ hp-elitedesk ansible_host=192.168.87.10
 ; agent-node1 ansible_host=192.168.202.13
 ; agent-node2 ansible_host=192.168.202.15
 macmini-2010 ansible_host=192.168.87.11
-battlestation-ubuntu ansible_host=192.168.87.12
+; battlestation-ubuntu ansible_host=192.168.87.12
 
 [all:vars]
 ansible_user=ansible

--- a/roles/install_k3s_agents/tasks/main.yml
+++ b/roles/install_k3s_agents/tasks/main.yml
@@ -11,6 +11,8 @@
   failed_when: >
     install_k3s_agents_ufw_flannel_result.failed and
     'Could not find' not in
+    install_k3s_agents_ufw_flannel_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_agents_ufw_flannel_result.msg | default('')
 
 - name: Allow K3s API server access from cluster network
@@ -25,6 +27,8 @@
   failed_when: >
     install_k3s_agents_ufw_api_result.failed and
     'Could not find' not in
+    install_k3s_agents_ufw_api_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_agents_ufw_api_result.msg | default('')
 
 - name: Allow K3s kubelet API access from cluster network
@@ -39,6 +43,8 @@
   failed_when: >
     install_k3s_agents_ufw_kubelet_result.failed and
     'Could not find' not in
+    install_k3s_agents_ufw_kubelet_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_agents_ufw_kubelet_result.msg | default('')
 
 - name: Create k3s config directory
@@ -61,7 +67,7 @@
     dest: /etc/rancher/k3s/config.yaml
     content: |
       node-ip: "{{ ansible_host }}"
-      flannel-iface: "{{ ansible_default_ipv4.interface }}"
+      flannel-iface: "{{ ansible_facts['default_ipv4']['interface'] }}"
       kubelet-arg:
         - "resolv-conf=/etc/rancher/k3s/resolv.conf"
         - "system-reserved=cpu=250m,memory=512Mi"

--- a/roles/install_k3s_server/tasks/main.yml
+++ b/roles/install_k3s_server/tasks/main.yml
@@ -11,6 +11,8 @@
   failed_when: >
     install_k3s_server_ufw_flannel_result.failed and
     'Could not find' not in
+    install_k3s_server_ufw_flannel_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_server_ufw_flannel_result.msg | default('')
 
 - name: Allow K3s API server access from cluster network
@@ -25,6 +27,8 @@
   failed_when: >
     install_k3s_server_ufw_api_result.failed and
     'Could not find' not in
+    install_k3s_server_ufw_api_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_server_ufw_api_result.msg | default('')
 
 - name: Allow K3s kubelet API access from cluster network
@@ -39,6 +43,8 @@
   failed_when: >
     install_k3s_server_ufw_kubelet_result.failed and
     'Could not find' not in
+    install_k3s_server_ufw_kubelet_result.msg | default('') and
+    'Failed to find' not in
     install_k3s_server_ufw_kubelet_result.msg | default('')
 
 - name: Create k3s config directory
@@ -63,7 +69,7 @@
       cluster-dns: "10.43.0.10"
       cluster-domain: "cluster.local"
       node-ip: "{{ ansible_host }}"
-      flannel-iface: "{{ ansible_default_ipv4.interface }}"
+      flannel-iface: "{{ ansible_facts['default_ipv4']['interface'] }}"
       flannel-backend: "vxlan"
       disable-network-policy: true
       kubelet-arg:


### PR DESCRIPTION
## Summary
- Update `failed_when` conditions to handle 'Failed to find' error for missing ufw executable
- Use `ansible_facts['default_ipv4']['interface']` instead of deprecated `ansible_default_ipv4.interface` syntax
- Comment out battlestation-ubuntu in inventory (currently offline)

## Problem
- Playbook failed on nodes without ufw installed
- Deprecation warnings about INJECT_FACTS_AS_VARS in Ansible 2.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)